### PR TITLE
BUGFIX/MINOR(samba): Fix `samba_service_name` on RedHat family

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -20,7 +20,7 @@ ctdb_services:
 ctdb_nodes: /etc/ctdb/nodes
 ctdb_public_addresses: /etc/ctdb/public_addresses
 
-samba_service_name: smb
+samba_service_name: smbd
 
 ad_packages:
   - krb5-workstation


### PR DESCRIPTION
 ##### ISSUE TYPE
- Bugfix

 ##### SUMMARY
In cluster mode, samba is restarted. CTDB's resource is in error after a change in smb.conf

 ##### SCOPE (skeleton only)
- samba

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION