### PR TITLE
BUGFIX/MINOR(samba): Fix the use of tags `install` and `configure`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@
 # Compiled Python
 *.pyc
 
-# Test directories. These are Git worktrees to separate test branches
-*tests/
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --only-upgrade git
   # Allow fetching other branches than master
-  - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  #- git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
   # Fetch the branch with test code
-  - git fetch origin docker-tests
-  - git worktree add docker-tests origin/docker-tests
+  #- git fetch origin docker-tests
+  #- git worktree add docker-tests origin/docker-tests
   # retrieve centralized script
   - |
     for i in docker-tests.sh functional-tests.sh ansible.cfg; do

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,0 +1,20 @@
+# Docker test environment
+
+1. Fetch the test branch: `git fetch origin docker-tests`
+2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
+3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/cdelgehier/docker_images_ansible/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+
+    ```
+    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=ubuntu VERSION=16.04 ANSIBLE_VERSION=2.5 ./docker-tests/docker-tests.sh
+    ```
+4. You can test another use case by adding an argument to the script. An argument `<another>` will apply a playbook `<another.yml>`
+
+5. You can run functionnal tests locally like that:
+
+    ```
+    SUT_ID=9acda29c356b ./docker-tests/functional-tests.sh
+    SUT_IP=172.17.0.2   ./docker-tests/functional-tests.sh
+    ```
+   
+The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/docker-tests/ansible.cfg
+++ b/docker-tests/ansible.cfg
@@ -1,0 +1,15 @@
+[defaults]
+
+stdout_callback = yaml
+callback_whitelist = profile_tasks
+ansible_managed = OpenIO managed
+deprecation_warnings = True
+
+[colors]
+diff_remove = purple
+
+
+[diff]
+# Always print diff when running ( same as always running with -D/--diff )
+always = yes
+

--- a/docker-tests/checks.bats
+++ b/docker-tests/checks.bats
@@ -1,0 +1,25 @@
+#! /usr/bin/env bats
+
+# Variable SUT_IP should be set outside this script and should contain the IP
+# address of the System Under Test.
+
+# Tests
+@test 'Check smb.conf' {
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/samba/smb.conf"
+  echo "output: "$output
+  echo "status: "$status
+  [[ "${status}" -eq "0" ]]
+  [[ "${output}" =~ "[foo]" ]]
+  [[ "${output}" =~ "path = /tmp/foo" ]]
+  [[ "${output}" =~ "[bar]" ]]
+  [[ "${output}" =~ "path = /tmp/bar" ]]
+}
+
+@test 'Check testparm' {
+  run bash -c "docker exec -ti ${SUT_ID} testparm -s"
+  echo "output: "$output
+  echo "status: "$status
+  [[ "${status}" -eq "0" ]]
+  [[ "${output}" =~ "Loaded services file OK" ]]
+}
+

--- a/docker-tests/docker-tests.sh
+++ b/docker-tests/docker-tests.sh
@@ -1,0 +1,205 @@
+#! /usr/bin/env bash
+#
+# Author: Bert Van Vreckem <bert.vanvreckem@gmail.com>
+#
+# Runs tests for this Ansible role on a Docker container
+# Environment variables DISTRIBUTION and VERSION must be set
+# outside of the script, e.g.
+#
+# $ DISTRIBUTION=centos VERSION=7 docker-tests.sh
+
+#{{{ Bash settings
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset
+# don't hide errors within pipes
+set -o pipefail
+#}}}
+#{{{ Variables
+readonly script_name=$(basename "${0}")
+readonly script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+IFS=$'\t\n'   # Split on newlines and tabs (but not on spaces)
+
+readonly container_id="$(mktemp)"
+readonly role_dir='/etc/ansible/roles/role_under_test'
+if [ "$#" -ne 1 ]; then
+    readonly test_playbook="${role_dir}/docker-tests/test.yml"
+else
+    readonly test_playbook="${role_dir}/docker-tests/$1.yml"
+fi
+readonly requirements="${role_dir}/docker-tests/requirements.yml"
+
+readonly docker_image="cdelgehier/docker_images_ansible"
+readonly image_tag="${docker_image}:${ANSIBLE_VERSION}_${DISTRIBUTION}_${VERSION}"
+
+# Distribution specific settings
+init="/sbin/init"
+run_opts=("--privileged")
+#}}}
+
+main() {
+  configure_environment
+
+  start_container
+
+  run_galaxy_install
+  run_syntax_check
+  run_test_playbook
+  run_idempotence_test
+
+  # Uncomment the following line if you want to clean up the
+  # container(s) after running the tests. *Not* cleaning up may be
+  # useful for troubleshooting
+
+  # cleanup
+}
+
+#{{{ Helper functions
+
+# Usage: configure_environment.
+#
+# This function defines run options for Docker, depending on the
+# Linux $DISTRIBUTION and $VERSION.
+configure_environment() {
+
+  case "${DISTRIBUTION}_${VERSION}" in
+    'centos_6')
+      run_opts+=('--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro')
+      ;;
+    'centos_8'|'centos_7'|'fedora_25')
+      init=/usr/lib/systemd/systemd
+      run_opts+=('--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro')
+      ;;
+    'ubuntu_14.04')
+      #run_opts+=('--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro')
+      # Workaround for issue when the host operating system has SELinux
+      if [ -x '/usr/sbin/getenforce' ]; then
+        run_opts+=('--volume=/sys/fs/selinux:/sys/fs/selinux:ro')
+      fi
+      ;;
+    'ubuntu_18.04'|'ubuntu_16.04'|'debian_8')
+      run_opts=('--volume=/run' '--volume=/run/lock' '--volume=/tmp' '--volume=/sys/fs/cgroup:/sys/fs/cgroup:ro' '--cap-add=NET_ADMIN' '--cap-add=SYS_ADMIN' '--cap-add=SYS_RESOURCE')
+
+      #if [ -x '/usr/sbin/getenforce' ]; then
+      #  run_opts+=('--volume=/sys/fs/selinux:/sys/fs/selinux:ro')
+      #fi
+      ;;
+    *)
+      log "Warning: no run options added for ${DISTRIBUTION} ${VERSION}"
+      ;;
+  esac
+}
+
+# Usage: build_container
+build_container() {
+  log "Building container for ${DISTRIBUTION} ${VERSION}"
+  set -x
+  docker build --tag="${image_tag}" .
+  set +x
+}
+
+start_container() {
+  log "Starting container"
+  set -x
+  docker run --detach \
+    "${run_opts[@]}" \
+    --volume="${PWD}:${role_dir}:ro" \
+    -e IPVAGRANT=${IPVAGRANT:=""} \
+    -e USR=${USR:=""} \
+    -e PASS=${PASS:=""} \
+    "${image_tag}" \
+    "${init}" \
+    > "${container_id}"
+  set +x
+}
+
+get_container_id() {
+  cat "${container_id}"
+}
+
+# Usage: get_container_ip CONTAINER_ID
+#
+# Prints the IP address of the specified container.
+get_container_ip() {
+  local id
+  id="$(get_docker_id)"
+
+  docker inspect \
+    --format '{{ .NetworkSettings.IPAddress }}' \
+    "${id}"
+}
+
+# Usage: exec_container COMMAND
+#
+# Run COMMAND on the Docker container
+exec_container() {
+  local id
+  id="$(get_container_id)"
+
+  set -x
+  docker exec --tty \
+    "${id}" \
+    env TERM=xterm \
+    "${@}"
+  set +x
+}
+
+run_syntax_check() {
+  log 'Running syntax check on playbook'
+  exec_container ansible-playbook "${test_playbook}" --syntax-check
+  log 'Syntax check finished'
+}
+
+run_test_playbook() {
+  log 'Running playbook'
+  exec_container ansible-playbook "${test_playbook}" --diff
+  log 'Run finished'
+}
+
+run_galaxy_install() {
+  log "Running ansible-galaxy install"
+  exec_container ansible-galaxy install -r "${requirements}"
+  log "Requirements installed"
+}
+
+run_idempotence_test() {
+  log 'Running idempotence test'
+  local output
+  output="$(mktemp)"
+
+  exec_container ansible-playbook "${test_playbook}" --diff 2>&1 | tee "${output}"
+
+  if grep -q "changed=${NORMALCHANGES:=0}.*failed=0" "${output}"; then
+    result='pass'
+    return_status=0
+  else
+    result='fail'
+    return_status=1
+  fi
+  rm "${output}"
+
+  log "Result: ${result}"
+  return "${return_status}"
+}
+
+cleanup() {
+  log 'Cleaning up'
+  local id
+  id="$(get_container_id)"
+
+  docker stop "${id}"
+  docker rm "${id}"
+  rm "${container_id}"
+}
+
+log() {
+  local yellow='\e[0;33m'
+  local reset='\e[0m'
+
+  printf "${yellow}>>> %s${reset}\n" "${*}"
+}
+
+#}}}
+
+main "${@}"

--- a/docker-tests/functional-tests.sh
+++ b/docker-tests/functional-tests.sh
@@ -1,0 +1,111 @@
+#! /usr/bin/env bash
+#
+# Author:   Bert Van Vreckem <bert.vanvreckem@gmail.com>
+#
+# Run BATS test files in the current directory, and the ones in the subdirectory
+# matching the host name.
+#
+# The script installs BATS if needed. It's best to put ${bats_install_dir} in
+# your .gitignore.
+
+set -o errexit  # abort on nonzero exitstatus
+set -o nounset  # abort on unbound variable
+
+#{{{ Variables
+
+test_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bats_archive="v0.4.0.tar.gz"
+bats_url="https://github.com/sstephenson/bats/archive/${bats_archive}"
+bats_install_dir="/opt"
+bats_default_location="${bats_install_dir}/bats/libexec/bats"
+test_file_pattern="*.bats"
+
+# Color definitions
+readonly reset='\e[0m'
+readonly yellow='\e[0;33m'
+readonly cyan='\e[0;36m'
+#}}}
+
+main() {
+
+  bats=$(find_bats_executable)
+
+  if [ -z "${bats}" ]; then
+    install_bats
+    bats="${bats_default_location}"
+  fi
+
+  debug "Using BATS executable at: ${bats}"
+
+  # List all test cases (i.e. files in the test dir matching the test file
+  # pattern)
+
+  # Tests to be run on all hosts
+  global_tests=$(find_tests "${test_dir}" 1)
+
+  # Tests for individual hosts
+  host_tests=$(find_tests "${test_dir}/${HOSTNAME}")
+
+  # Loop over test files
+  for test_case in ${global_tests} ${host_tests}; do
+    info "Running test ${test_case}"
+    ${bats} "${test_case}"
+  done
+}
+
+#{{{ Functions
+
+# Tries to find BATS executable in the PATH or the place where this script
+# installs it.
+find_bats_executable() {
+  if which bats > /dev/null;  then
+    which bats
+  elif [ -x "${bats_default_location}" ]; then
+    echo "${bats_default_location}"
+  else
+    echo ""
+  fi
+}
+
+# Usage: install_bats
+install_bats() {
+  pushd "${bats_install_dir}" > /dev/null 2>&1
+  curl --location --remote-name "${bats_url}"
+  tar xzf "${bats_archive}"
+  mv bats-* bats
+  rm "${bats_archive}"
+  popd > /dev/null 2>&1
+}
+
+# Usage: find_tests DIR [MAX_DEPTH]
+#
+# Finds BATS test suites in the specified directory
+find_tests() {
+  local max_depth=""
+  if [ "$#" -eq "2" ]; then
+    max_depth="-maxdepth $2"
+  fi
+
+  local tests
+  tests=$(find "$1" ${max_depth} -type f -name "${test_file_pattern}" -printf '%p\n' 2> /dev/null)
+
+  echo "${tests}"
+}
+
+# Usage: info [ARG]...
+#
+# Prints all arguments on the standard output stream
+info() {
+  printf "${yellow}### %s${reset}\n" "${*}"
+}
+
+# Usage: debug [ARG]...
+#
+# Prints all arguments on the standard output stream
+debug() {
+  printf "${cyan}### %s${reset}\n" "${*}"
+}
+#}}}
+
+main

--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,0 +1,5 @@
+---
+- src: https://github.com/open-io/ansible-role-openio-users.git
+  version: "19.04"
+  name: users
+...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -1,0 +1,41 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - role: role_under_test
+      openio_samba_service_state: stopped
+      openio_samba_service_enabled: false
+      openio_samba_ctdb: true
+      openio_samba_ctdb_service_state: stopped
+      openio_samba_ctdb_service_enabled: false
+      openio_samba_ctdb_recovery_lock: /some/place/on/shared/storage/ctdb/lock
+      openio_samba_ctdb_manages_samba: "yes"
+      openio_samba_ctdb_manages_winbind: "yes"
+      openio_samba_ctdb_manages_nfs: "no"
+      openio_samba_ctdb_nodes_list:
+        - 127.0.0.1
+        - 127.0.0.2
+      openio_samba_mountpoints:
+        - comment: Samba
+          ? "ea support"
+          : "yes"
+          export_name: foo
+          path: /tmp/foo
+          public: "yes"
+          ? "read only"
+          : "no"
+          ? "vfs objects"
+          : "catia fruit streams_xattr"
+          writeable: "yes"
+        - comment: Samba
+          ? "ea support"
+          : "yes"
+          export_name: bar
+          path: /tmp/bar
+          public: "no"
+          ? "read only"
+          : "yes"
+          ? "vfs objects"
+          : "catia fruit streams_xattr"
+          writeable: "no"
+...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,4 +11,5 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -11,6 +11,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: CTDB - packages
   package:
@@ -25,6 +26,7 @@
   retries: 5
   delay: 2
   when: openio_samba_ctdb
+  tags: install
 
 - name: Active Directory - packages
   package:
@@ -39,4 +41,5 @@
   retries: 5
   delay: 2
   when: openio_samba_active_directory
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: "Include {{ ansible_distribution }} tasks"
   include_tasks: "{{ item }}"
@@ -28,12 +30,14 @@
         - { 'name': 'dns_lookup_kdc', 'value': 'true' }
         - { 'name': 'dns_lookup_realm', 'value': 'false' }
         - { 'name': 'default_realm', 'value': "{{ openio_samba_active_directory.domain_name | upper }}" }
+      tags: configure
 
     - name: Configure resolv.conf
       template:
         src: resolv.conf.j2
         dest: /etc/resolv.conf
       register: _resolv_conf
+      tags: configure
 
     - name: Add entry in /etc/hosts
       lineinfile:
@@ -41,6 +45,7 @@
         line: "{{ openio_samba_active_directory.samba_address }} \
           {{ openio_samba_server_name }}.{{ openio_samba_active_directory.domain_name }} \
           {{ openio_samba_server_name }}"
+      tags: configure
 
     - name: Update /etc/nsswitch.conf
       lineinfile:
@@ -50,7 +55,7 @@
       with_items:
         - { regexp: '^passwd:.*', line: 'passwd: files winbind' }
         - { regexp: '^group:.*', line: 'group: files winbind' }
-
+      tags: configure
 
   when: openio_samba_active_directory
 
@@ -61,6 +66,7 @@
   failed_when: false
   register: _ctdb_running
   when: openio_samba_ctdb
+  tags: configure
 
 - block:
     - name: CTDB - Ensure lock directory exists
@@ -68,6 +74,7 @@
         path: "{{ openio_samba_ctdb_recovery_lock | dirname }}"
         state: directory
         mode: 0755
+      tags: configure
 
     - name: CTDB - Configuration
       template:
@@ -80,6 +87,7 @@
         - { src: 'ctdb.conf.j2', dest: '/etc/ctdb/ctdbd.conf' }
         - { src: 'ctdb.nodes.j2', dest: '{{ ctdb_nodes }}' }
         - { src: 'public_addresses.j2', dest: '{{ ctdb_public_addresses }}' }
+      tags: configure
   when:
     - openio_samba_ctdb
 
@@ -90,12 +98,14 @@
         state: "{{ openio_samba_ctdb_service_state }}"
         enabled: "{{ openio_samba_ctdb_service_enabled }}"
       with_items: "{{ ctdb_services }}"
+      tags: configure
 
     - name: CTDB - Ensure lock directory exists
       file:
         path: "{{ openio_samba_ctdb_recovery_lock | dirname }}"
         state: directory
         mode: 0755
+      tags: configure
   when:
     - openio_samba_ctdb
     - _ctdb_running.rc is defined
@@ -106,6 +116,7 @@
   changed_when: false
   failed_when: false
   register: _samba_running
+  tags: configure
 
 - name: SAMBA - Configuration
   template:
@@ -115,12 +126,13 @@
     owner: root
     group: root
     validate: 'testparm -s %s'
+  tags: configure
 
 - name: Add node to Active Directory
   command: "net ads join -U '{{openio_samba_active_directory.admin }}%{{ openio_samba_active_directory.password }}'"
   run_once: true
   when: openio_samba_active_directory
-
+  tags: configure
 
 - name: SAMBA - service
   service:
@@ -128,6 +140,7 @@
     state: "{{ openio_samba_service_state }}"
     enabled: "{{ openio_samba_service_enabled }}"
   with_items: "{{ samba_services }}"
+  tags: configure
   when:
     - _samba_running.rc is defined
     - _samba_running.rc != 0


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION